### PR TITLE
Update install.js

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -13,7 +13,7 @@ if (os.type() === 'Darwin') {
 } else if (os.type() === 'Linux') {
   runTime = 'linux-x64'
 } else if (os.type() === 'Windows_NT') {
-  if (process.arch === 'x32') {
+  if (process.arch === 'ia32') {
     runTime = 'win-x86'
   } else if (process.arch === 'x64') {
     runTime = 'win-x64'


### PR DESCRIPTION
valid values for process.arch = ‘arm’, ‘ia32’, or ‘x64’.

Presumably, if I'm running the 32b version of node, I want to install the win-x86 version of tssqllint? If we still want to install win-x64 here if the os is 64bit, we can also look at process.env.hasOwnProperty(‘PROCESSOR_ARCHITEW6432’);